### PR TITLE
(docs) Note changes on every run with 'notify'

### DIFF
--- a/lib/puppet/type/notify.rb
+++ b/lib/puppet/type/notify.rb
@@ -4,7 +4,7 @@
 
 module Puppet
   Type.newtype(:notify) do
-    @doc = "Sends an arbitrary message to the agent run-time log."
+    @doc = "Sends an arbitrary message to the agent run-time log. It's important to note that the notify resource type is not idempotent. As a result, notifications are shown as a change on every Puppet run."
 
     apply_to_all
 


### PR DESCRIPTION
This addition was suggested by a Puppet docs site feedback provider, who cited PUP-1113 and pointed out that the 'notify' resource type doc currently doesn't mention this type's lack of idempotency.